### PR TITLE
Fix custom commands in velocity

### DIFF
--- a/velocity/src/main/java/com/github/donotspampls/ezprotector/velocity/listeners/CustomCommands.java
+++ b/velocity/src/main/java/com/github/donotspampls/ezprotector/velocity/listeners/CustomCommands.java
@@ -36,7 +36,7 @@ public class CustomCommands {
 
                 if (!player.hasPermission("ezprotector.bypass.command.custom")) {
                     for (Object message : config.getList("custom-commands.commands")) {
-                        if (command.equalsIgnoreCase((String) message)) {
+                        if (command.startsWith((String) message)) {
                             event.setResult(CommandExecuteEvent.CommandResult.denied());
 
                             String errorMessage = config.getString("custom-commands.error-message");

--- a/velocity/src/main/java/com/github/donotspampls/ezprotector/velocity/listeners/CustomCommands.java
+++ b/velocity/src/main/java/com/github/donotspampls/ezprotector/velocity/listeners/CustomCommands.java
@@ -36,7 +36,7 @@ public class CustomCommands {
 
                 if (!player.hasPermission("ezprotector.bypass.command.custom")) {
                     for (Object message : config.getList("custom-commands.commands")) {
-                        if (command.startsWith((String) message)) {
+                        if (command.equalsIgnoreCase((String) message) || command.startsWith((String) message + " ")) {
                             event.setResult(CommandExecuteEvent.CommandResult.denied());
 
                             String errorMessage = config.getString("custom-commands.error-message");


### PR DESCRIPTION
If the custom-commands feature is enabled and an executed command hasn't any arguments, it won't be executed (as excepted), but if it has arguments, it will be executed (not excepted)